### PR TITLE
Added view-height and scrolling to "My Subverses"

### DIFF
--- a/Voat/Voat.UI/Content/Voat.css
+++ b/Voat/Voat.UI/Content/Voat.css
@@ -1388,6 +1388,9 @@ pre, code {
             position: absolute;
             visibility: hidden;
             z-index: 99;
+            overflow-x: hidden;
+            overflow-y: scroll;
+            height: 80vh;
         }
 
             .whoaSubscriptionMenu li ul li {


### PR DESCRIPTION
The subverse menu was far off the screen and if you scrolled down too quickly you often scrolled off of it. This change adds 80% height to the menu and makes it scrollable.
